### PR TITLE
Fix FieldTextInput showPromptEditor_

### DIFF
--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -153,7 +153,7 @@ Blockly.FieldTextInput.prototype.showEditor_ = function(opt_quietInput) {
  * Mobile browsers have issues with in-line textareas (focus and keyboards).
  * @private
  */
-Blockly.FieldTextInput.showPromptEditor_ = function() {
+Blockly.FieldTextInput.prototype.showPromptEditor_ = function() {
   var fieldText = this;
   Blockly.prompt(Blockly.Msg.CHANGE_VALUE_TITLE, this.text_,
     function(newValue) {


### PR DESCRIPTION
### Resolves

https://github.com/google/blockly/issues/1348

### Proposed Changes

Put `showPromptEditor_` on the prototype.

### Reason for Changes

The previous code was a mistake from a cleanup PR.

### Test Coverage

This matters for mobile platforms (iOS and Android) which we will test once this is cherry-picked into the release.

Tested on:

- [ ] Smartphone/Tablet/Chromebook (please complete the following information):
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
  
