### PR TITLE
Fix iOS toolbox flashing on tap

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -517,6 +517,7 @@ Blockly.Css.CONTENT = [
     'overflow-y: auto;',
     'position: absolute;',
     'z-index: 70;', /* so blocks go under toolbox when dragging */
+    '-webkit-tap-highlight-color: transparent;', /* issue #1345 */
   '}',
 
   '.blocklyTreeRoot {',

--- a/core/field_textinput.js
+++ b/core/field_textinput.js
@@ -153,7 +153,7 @@ Blockly.FieldTextInput.prototype.showEditor_ = function(opt_quietInput) {
  * Mobile browsers have issues with in-line textareas (focus and keyboards).
  * @private
  */
-Blockly.FieldTextInput.showPromptEditor_ = function() {
+Blockly.FieldTextInput.prototype.showPromptEditor_ = function() {
   var fieldText = this;
   Blockly.prompt(Blockly.Msg.CHANGE_VALUE_TITLE, this.text_,
     function(newValue) {


### PR DESCRIPTION
Thanks for submitting code to Blockly!  Please fill out the following as part of your pull request so we can review your code more easily.

## The basics

- [x] I branched from develop
- [ ] My pull request is against develop __My PR is against the release candidate.__
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

https://github.com/google/blockly/issues/1345

### Proposed Changes

Use CSS to get rid of iOS's default tap higlight color on elements.

### Reason for Changes

Surfacing default browser mousedown events exposed this issue.

### Test Coverage

Will test on iOS
Doesn't do anything on other platforms.

Tested on:

- [ ] Smartphone/Tablet/Chromebook (please complete the following information):
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
  
### Additional Information
This is a cherry-pick of a change that will also go to develop.
